### PR TITLE
Chartley/fix-page-generation

### DIFF
--- a/pages/deck/cardTest.ts
+++ b/pages/deck/cardTest.ts
@@ -1,0 +1,21 @@
+import { createCard } from "../../src/components/card/card";
+import "../../src/styles/style.css";
+import "../../src/styles/card.css";
+import "../../src/styles/theme.css";
+import "./styles.css";
+import "../../src/components/navMenu/navMenu";
+
+function instanceCard() {
+	const card = createCard();
+	card.wrapper.addEventListener("click", () => {
+		card.flipCard();
+	});
+
+	return card;
+}
+
+const app = document.getElementById("app");
+if (app) {
+	const testCard = instanceCard();
+	app.appendChild(testCard.wrapper);
+}

--- a/pages/deck/index.html
+++ b/pages/deck/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + TS</title>
+  </head>
+  <body>
+    <div id="app">
+    </div>
+    <script type="module" src="./cardTest.ts"></script>
+  </body>
+</html>

--- a/src/components/navMenu/navMenu.ts
+++ b/src/components/navMenu/navMenu.ts
@@ -15,8 +15,12 @@ const navMenuData: NavItem[] = [
 		slug: "/docs/",
 	},
 	{
-		text: "Single Card Testing",
+		text: "Card",
 		slug: "/card/",
+	},
+	{
+		text: "Deck",
+		slug: "/deck/",
 	},
 ];
 


### PR DESCRIPTION
Previously, you'd have to add an entry to vite config every time you add
a new folder to pages. Now, the directory is crawled, and the pages are
routed correctly.

Fixes #10


### Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

### Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Screenshots (if appropriate):

### Additional Notes:
Any additional information that you want to provide.